### PR TITLE
Fix forgoten parametr

### DIFF
--- a/src/morecat_admin_web/routes/entries.clj
+++ b/src/morecat_admin_web/routes/entries.clj
@@ -38,7 +38,7 @@
     (see-other "/entries")))
 
 (defroutes entries-routes
-           (context "/entries"
+           (context "/entries" []
              (GET "/" [] (entries-page))
              (GET "/new" [] (entry-new-page))
              (POST "/new" [& form] (entry-new-submit form))


### PR DESCRIPTION
``` sh
CompilerException java.lang.Exception: Unsupported binding form: (GET "/" [] (entries-page)), compiling:(/path/to/morecat-admin-web/src/morecat_admin_web/routes/entries.clj:41:12) 
```
